### PR TITLE
Feat/allow runtime optimizations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ test name 2 2
 ```javascript
 const options = {
 	silent?: boolean
-		// default = false. Prints results to console
+		// default = false. Prevents prints results to console if true.
+	allowRuntimeOptimizations?: boolean
+		// default: false. Will run test without most optimization prevention techniques.
+		// Result; More real numbers, more variability. (less stable results)
 	maxItrCount?: number
 		// default: 2 000 000. Target total number of calls to task function.
 	maxItrTimeSeconds?: number

--- a/src/BenchmarkResult.ts
+++ b/src/BenchmarkResult.ts
@@ -18,4 +18,4 @@ export type BenchmarkResult = {
 	maxTime?: string;
 	dropped: number;
 	rank: number;
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { BenchmarkResult } from "./BenchmarkResult"
-import { Task } from "./Task";
+import { BenchmarkResult } from './BenchmarkResult'
+import { Task } from "./Task"
 
 // From MDN docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction
 const AsyncFunction = Object.getPrototypeOf(async function () {/* Intentionally left blank */ }).constructor;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,6 +143,51 @@ describe('CodeBench', () => {
 		expect(results[0].rank).toBe(1)
 		expect(results[1].rank).toBe(2)
 		expect(results[0]?.opsPerSecondRaw).toBeGreaterThan(results[1]?.opsPerSecondRaw)
-
 	})
+	test('allowRuntimeOptimizations', async () => {
+		const cb = new CodeBench({
+			silent: false,
+			dynamicIterationCount: true,
+			allowRuntimeOptimizations: true,
+		})
+		cb.task("fastest", () => {
+			const a = 2*2
+		})
+		cb.task("slowest", () => {
+			for (let index = 0; index < 200; index++) {
+				const a = 2*2
+			}
+		})
+		const results = await cb.run()
+
+
+		expect(results[0].rank).toBe(1)
+		expect(results[1].rank).toBe(2)
+		expect(results[0]?.opsPerSecondRaw).toBeGreaterThan(results[1]?.opsPerSecondRaw)
+
+		const cb2 = new CodeBench({
+			silent: false,
+			dynamicIterationCount: true,
+			allowRuntimeOptimizations: false,
+		})
+		cb2.task("fastest", () => {
+			const a = 2*2
+		})
+		cb2.task("slowest", () => {
+			for (let index = 0; index < 200; index++) {
+				const a = 2*2
+			}
+		})
+		const results2 = await cb2.run()
+
+
+		expect(results2[0].rank).toBe(1)
+		expect(results2[1].rank).toBe(2)
+		expect(results2[0]?.opsPerSecondRaw).toBeGreaterThan(results2[1]?.opsPerSecondRaw)
+
+		// Comparing methods
+		expect(results[0]?.opsPerSecondRaw).toBeGreaterThan(results2[0]?.opsPerSecondRaw)
+		expect(results[1]?.opsPerSecondRaw).toBeGreaterThan(results2[1]?.opsPerSecondRaw)
+	})
+
 })


### PR DESCRIPTION
Will allow benchmarks to run without the different features made to prevent optimizations. The use case is to get a ballpark measure of more real-world performance.

After a small number of tests the numbers does not seem too bad on my laptop, and they seems to be almost equivalent when considering stability, but the ops/sec is much higher, almost twice.